### PR TITLE
Removed unused variable Component

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -29,7 +29,7 @@
 
   "preactStateless": {
     "prefix": "psc",
-    "body": "import { h, Component } from 'preact';\n\nconst ${1:componentName} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};\n\nexport default ${1:componentName};",
+    "body": "import { h } from 'preact';\n\nconst ${1:componentName} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};\n\nexport default ${1:componentName};",
     "description": "Creates a stateless Preact component without PropTypes and ES6 module system"
   },
   "preactStatelessProps": {


### PR DESCRIPTION
Hello @SaraVieira 

Thank you for the lib, i just noticed a simple small fix, when using the `psc` the snippet inserts `component` to the code, this is not needed since we are creating a stateless component.

If you have any thing to note on the PR please let me know.